### PR TITLE
Print URL in terminal messaging

### DIFF
--- a/tools/serve.js
+++ b/tools/serve.js
@@ -50,7 +50,8 @@ function listen(port) {
 
   log('Starting up Server, serving '.yellow
     + __dirname.replace("tools", '').green
-    + ' on port: '.yellow
+    + ' on: '.yellow
+    + 'http://localhost:'.cyan
     + port.toString().cyan);
   log('Hit CTRL-C to stop the server');
 


### PR DESCRIPTION
Currently, the terminal messaging after the server spins up is:

```
Starting up Server, serving [...]/epubjs-reader/ on port: 8080
```

This PR changes the messaging to:

```
Starting up Server, serving [...]/epubjs-reader/ on: http://localhost:8080
```

This allows users who have enhanced terminals to recognize the URL for easier loading in the browser.