### PR TITLE
Improve markup for settings checkbox

### DIFF
--- a/reader/index.html
+++ b/reader/index.html
@@ -106,7 +106,8 @@
               <h3>Settings</h3>
               <div>
                   <p>
-                    <input type="checkbox" id="sidebarReflow" name="sidebarReflow">Reflow text when sidebars are open.
+                    <input type="checkbox" id="sidebarReflow" name="sidebarReflow">
+                    <span>Reflow text when sidebars are open.</span>
                   </p>
               </div>
               <div class="closer icon-cancel-circled"></div>

--- a/reader/index.html
+++ b/reader/index.html
@@ -107,7 +107,7 @@
               <div>
                   <p>
                     <input type="checkbox" id="sidebarReflow" name="sidebarReflow">
-                    <span>Reflow text when sidebars are open.</span>
+                    <label for="sidebarReflow">Reflow text when sidebars are open.</label>
                   </p>
               </div>
               <div class="closer icon-cancel-circled"></div>


### PR DESCRIPTION
Currently, the settings modal renders like this:

<img width="658" alt="before" src="https://user-images.githubusercontent.com/6126950/65392229-7e698200-dd40-11e9-8f47-3a2f2eaad251.png">

After these changes, it renders as:

<img width="666" alt="after" src="https://user-images.githubusercontent.com/6126950/65392231-80cbdc00-dd40-11e9-8910-d19093bf9092.png">

Also, the text was made into a label for the checkbox so that you can click the label to toggle the checkbox.