### PR TITLE
Typo - to start it

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install
 You can run the reader locally with the command
 
 ```javascript
-node start
+npm start
 ```
 
 Builds are concatenated and minified using [gruntjs](http://gruntjs.com/getting-started)


### PR DESCRIPTION
It said `node start` which of course complains 
```
node start
internal/modules/cjs/loader.js:783
    throw err;
    ^

Error: Cannot find module '/Users/mitra/git/epubjs-reader/start'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:780:15)
    at Function.Module._load (internal/modules/cjs/loader.js:685:27)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1014:10)
    at internal/main/run_main_module.js:17:11 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
```
Pretty sure it meant `npm start` to run the `"start": "node tools/serve",` line in package.json